### PR TITLE
Add styled GitHub Pages index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BTC Treasury Tickers</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background-color: #121212;
+      color: #eee;
+      font-family: 'Inter', Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      text-align: center;
+    }
+    .container {
+      padding: 40px 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    img.logo {
+      width: 120px;
+      margin: 20px auto;
+      display: block;
+    }
+    h1 {
+      font-size: 2em;
+      margin-bottom: 20px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid #444;
+      padding: 12px;
+    }
+    th {
+      background-color: #1f1f1f;
+    }
+    tr:nth-child(even) {
+      background-color: #1a1a1a;
+    }
+    @media (max-width: 600px) {
+      h1 {
+        font-size: 1.5em;
+      }
+      th, td {
+        padding: 8px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <img class="logo" src="https://cryptologos.cc/logos/bitcoin-btc-logo.png" alt="Bitcoin Logo">
+    <h1>Latest Bitcoin Treasury Tickers</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Ticker</th>
+          <th>Company</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>PRE</td>
+          <td>Prenetics</td>
+          <td>June 19, 2025</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign `/docs/index.html` with centered layout
- add Bitcoin logo, responsive styling, and modern font

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68546c6419408333a236f42f574670b4