### PR TITLE
Expand GitHub Pages site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Live tracker of companies adding Bitcoin to their treasury. No ETFs.">
+  <title>BTC Treasury Tickers</title>
+  <link rel="icon" href="https://cryptologos.cc/logos/bitcoin-btc-logo.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      background-color: #121212;
+      color: #eee;
+      font-family: 'Inter', Arial, sans-serif;
+    }
+    .wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    header img {
+      width: 120px;
+      height: auto;
+    }
+    h1 {
+      margin-top: 20px;
+      margin-bottom: 30px;
+      font-size: 2em;
+    }
+    #ticker-banner {
+      overflow-x: auto;
+      white-space: nowrap;
+      margin-bottom: 20px;
+      font-size: 0.9em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 12px;
+      border: 1px solid #444;
+    }
+    th {
+      background-color: #1f1f1f;
+    }
+    tr:nth-child(even) {
+      background-color: #1a1a1a;
+    }
+    footer {
+      margin-top: 40px;
+      font-size: 0.9em;
+      color: #ccc;
+    }
+    @media (max-width: 600px) {
+      h1 {
+        font-size: 1.5em;
+      }
+      th, td {
+        padding: 8px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <header>
+      <img src="https://cryptologos.cc/logos/bitcoin-btc-logo.png" alt="Bitcoin logo">
+      <h1>Latest Bitcoin Treasury Tickers</h1>
+    </header>
+    <div id="ticker-banner"></div>
+    <main>
+      <table id="treasury-table">
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Company</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </main>
+    <footer>
+      Built by Sam. Auto-updates daily. <a href="news.html">Latest News</a>
+    </footer>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,0 +1,32 @@
+async function loadTreasuries() {
+  try {
+    const res = await fetch('treasuries.json');
+    const data = await res.json();
+    const tbody = document.querySelector('#treasury-table tbody');
+    data.forEach(item => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${item.ticker}</td><td>${item.company}</td><td>${item.date}</td>`;
+      tbody.appendChild(tr);
+    });
+  } catch (err) {
+    console.error('Error loading treasuries', err);
+  }
+}
+
+async function loadPrices() {
+  try {
+    const res = await fetch('prices.json');
+    const data = await res.json();
+    const banner = document.getElementById('ticker-banner');
+    banner.innerHTML = data
+      .map(p => `${p.ticker}: $${p.price} (${p.percentChange}%)`)
+      .join(' | ');
+  } catch (err) {
+    console.error('Error loading prices', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadTreasuries();
+  loadPrices();
+});

--- a/docs/news.html
+++ b/docs/news.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Latest News - BTC Treasury Tickers</title>
+  <link rel="icon" href="https://cryptologos.cc/logos/bitcoin-btc-logo.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      background-color: #121212;
+      color: #eee;
+      font-family: 'Inter', Arial, sans-serif;
+    }
+    .wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    h1 {
+      text-align: center;
+      margin-bottom: 30px;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+    li {
+      margin-bottom: 10px;
+    }
+    a {
+      color: #6ab0ff;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <h1>Latest News</h1>
+    <ul id="news-list"></ul>
+    <footer><a href="index.html">Back to Home</a></footer>
+  </div>
+  <script>
+  fetch('news.json')
+    .then(r => r.json())
+    .then(data => {
+      const list = document.getElementById('news-list');
+      data.forEach(item => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = item.url;
+        a.textContent = item.title;
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+    })
+    .catch(err => console.error('Error loading news', err));
+  </script>
+</body>
+</html>

--- a/docs/news.json
+++ b/docs/news.json
@@ -1,0 +1,4 @@
+[
+  {"title": "Prenetics expands Bitcoin holdings", "url": "#"},
+  {"title": "More companies adopt BTC", "url": "#"}
+]

--- a/docs/prices.json
+++ b/docs/prices.json
@@ -1,0 +1,4 @@
+[
+  {"ticker": "PRE", "price": 8.21, "percentChange": 1.5},
+  {"ticker": "TSLA", "price": 712.9, "percentChange": -0.8}
+]

--- a/docs/treasuries.json
+++ b/docs/treasuries.json
@@ -1,0 +1,4 @@
+[
+  {"ticker": "PRE", "company": "Prenetics", "date": "June 19, 2025"},
+  {"ticker": "TSLA", "company": "Tesla", "date": "June 18, 2025"}
+]


### PR DESCRIPTION
## Summary
- build a dynamic BTC treasury tracking site
- load prices and treasuries from JSON via `main.js`
- add sample data for treasuries, prices, and news
- include minimal news page linked from footer

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68546c6419408333a236f42f574670b4