### PR TITLE
Add dynamic treasury list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # BTC-Treasury-Tickers
-Provides tickers' for the latest Bitcoin treasury companies globally
+
+This project hosts a small web page that lists companies with Bitcoin treasuries.
+The data is loaded dynamically from the [data-btc-treasuries.com](https://github.com/baxter2/data-btc-treasuries.com) repository so the table is kept current.
+Simply open `docs/index.html` in a browser to see the latest tickers and transaction dates.

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,15 +67,13 @@
       location.reload();
     }
   </script>
+  <script src="script.js" defer></script>
 </head>
 <body>
   <div class="container">
     <img class="logo" src="https://cryptologos.cc/logos/bitcoin-btc-logo.png" alt="Bitcoin Logo">
     <h1>Latest Bitcoin Treasury Tickers</h1>
-    <ul>
-      <li>bitcointreasuries.net refreshed: July 1, 2025</li>
-      <li>bitcointreasuries.com refreshed: June 30, 2025</li>
-    </ul>
+    <p>Data sourced from <a href="https://github.com/baxter2/data-btc-treasuries.com" target="_blank">data-btc-treasuries.com</a></p>
     <button class="refresh-btn" onclick="refreshPage()">Refresh</button>
     <table>
       <thead>
@@ -85,17 +83,8 @@
           <th>Date</th>
         </tr>
       </thead>
-      <tbody>
-        <tr>
-          <td>PRE</td>
-          <td>Prenetics</td>
-          <td>June 19, 2025</td>
-        </tr>
-        <tr>
-          <td>NEW</td>
-          <td>ExampleCo <span class="new">new</span></td>
-          <td>June 20, 2025</td>
-        </tr>
+      <tbody id="data-body">
+        <tr><td colspan="3">Loading...</td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,40 @@
+async function loadData() {
+  const publicUrl = 'https://raw.githubusercontent.com/baxter2/data-btc-treasuries.com/master/public_companies.json';
+  const privateUrl = 'https://raw.githubusercontent.com/baxter2/data-btc-treasuries.com/master/private_companies.json';
+  let companies = [];
+  try {
+    const [pubRes, privRes] = await Promise.all([fetch(publicUrl), fetch(privateUrl)]);
+    const pubJson = await pubRes.json();
+    const privJson = await privRes.json();
+    companies = pubJson.concat(privJson);
+  } catch (err) {
+    console.error('Failed to fetch data', err);
+    return;
+  }
+  const rows = companies.map(comp => {
+    const latest = comp.transactions && comp.transactions[comp.transactions.length - 1];
+    if (!latest) return null;
+    const parts = latest.date.split('/');
+    const dateObj = new Date(`${parts[2]}-${parts[1]}-${parts[0]}`);
+    const ticker = comp.short_ticker || comp.long_ticker || comp.permalink || '';
+    return { ticker, name: comp.name, date: dateObj };
+  }).filter(Boolean);
+  rows.sort((a, b) => b.date - a.date);
+  const tbody = document.getElementById('data-body');
+  tbody.innerHTML = '';
+  rows.forEach(row => {
+    const tr = document.createElement('tr');
+    const t1 = document.createElement('td');
+    t1.textContent = row.ticker;
+    const t2 = document.createElement('td');
+    t2.textContent = row.name;
+    const t3 = document.createElement('td');
+    t3.textContent = row.date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    tr.appendChild(t1);
+    tr.appendChild(t2);
+    tr.appendChild(t3);
+    tbody.appendChild(tr);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadData);


### PR DESCRIPTION
## Summary
- dynamically pull tickers and dates from data-btc-treasuries.com
- improve page layout and documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854aa9dc0048333a8bebeaa8c6c1ba3