### PR TITLE
Revamp UI with bitcoin orange theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,9 @@
       padding: 0;
       text-align: center;
     }
+    a {
+      color: #f7931a;
+    }
     .container {
       padding: 40px 20px;
       max-width: 800px;
@@ -27,10 +30,12 @@
     h1 {
       font-size: 2em;
       margin-bottom: 20px;
+      color: #f7931a;
     }
     table {
       width: 100%;
       border-collapse: collapse;
+      border: 1px solid #f7931a;
     }
     th, td {
       border: 1px solid #444;
@@ -38,12 +43,13 @@
     }
     th {
       background-color: #1f1f1f;
+      color: #f7931a;
     }
     tr:nth-child(even) {
       background-color: #1a1a1a;
     }
     .new {
-      color: #0f0;
+      color: #f7931a;
       font-size: 0.8em;
       font-weight: 600;
     }
@@ -52,6 +58,9 @@
       padding: 10px 20px;
       font-size: 1em;
       cursor: pointer;
+      background-color: #f7931a;
+      color: #000;
+      border: none;
     }
     @media (max-width: 600px) {
       h1 {
@@ -87,6 +96,7 @@
         <tr><td colspan="3">Loading...</td></tr>
       </tbody>
     </table>
+    <p id="last-updated"></p>
   </div>
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -29,12 +29,13 @@ async function loadData() {
     const t2 = document.createElement('td');
     t2.textContent = row.name;
     const t3 = document.createElement('td');
-    t3.textContent = row.date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    t3.textContent = row.date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' });
     tr.appendChild(t1);
     tr.appendChild(t2);
     tr.appendChild(t3);
     tbody.appendChild(tr);
   });
+  document.getElementById('last-updated').textContent = `Data last fetched: ${new Date().toUTCString()}`;
 }
 
 document.addEventListener('DOMContentLoaded', loadData);


### PR DESCRIPTION
## Summary
- tweak CSS for an orange bitcoin look
- show when the data was fetched
- render dates in UTC

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6854ac474cd88333a3f0e3d4be0212a8