### PR TITLE
Add live BTC price

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 This project hosts a small web page that lists companies with Bitcoin treasuries.
 The data is loaded dynamically from the [data-btc-treasuries.com](https://github.com/baxter2/data-btc-treasuries.com) repository so the table is kept current.
 Simply open `docs/index.html` in a browser to see the latest tickers and transaction dates.
+The page now also shows the current Bitcoin price fetched from CoinGecko via open CORS proxies.

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
   <header>
     <img class="logo" src="https://cryptologos.cc/logos/bitcoin-btc-logo.png" alt="BTC">
     <h1>Fresh BTC Treasury Tickers</h1>
+    <p id="price" class="price">loading price…</p>
     <p id="stamp">loading…</p>
     <button id="reload">↻ refresh</button>
   </header>

--- a/docs/script.js
+++ b/docs/script.js
@@ -4,6 +4,8 @@ const proxies=[u=>`https://api.allorigins.win/raw?url=${encodeURIComponent(u)}`,
                u=>`https://proxy.cors.sh/${u}`];
 const tbody=document.getElementById('tbody');
 const stamp=document.getElementById('stamp');
+const priceEl=document.getElementById('price');
+const priceSrc='https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd';
 document.getElementById('reload').onclick=load;
 load(); setInterval(load,3600e3);
 
@@ -15,6 +17,19 @@ async function fetchHTML(url){
     }catch(_){}
   }
   throw Error('all proxies failed');
+}
+
+async function fetchPrice(){
+  for(const make of proxies){
+    try{
+      const r=await fetch(make(priceSrc),{headers:{'x-cors-api-key':'free'}});
+      if(r.ok){
+        const json=await r.json();
+        return json.bitcoin.usd;
+      }
+    }catch(_){}
+  }
+  throw Error('price fetch failed');
 }
 function parse(html){
   const doc=new DOMParser().parseFromString(html,'text/html');
@@ -42,6 +57,8 @@ function render(rows){
 async function load(){
   stamp.textContent='updating…';
   try{
+    const price=await fetchPrice();
+    priceEl.textContent='$'+price.toLocaleString();
     const html=await fetchHTML(sources[0]);
     render(parse(html));
     stamp.textContent='last update '+new Date().toLocaleString();

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,6 +6,7 @@ nav a{color:var(--fg);text-decoration:none}
 nav a.logo{font-weight:700;color:var(--orange)}
 header{text-align:center;padding:40px 10px}
 h1{color:var(--orange);font-size:2rem;margin-bottom:6px}
+#price{font-size:2.4rem;margin:10px 0;font-weight:700}
 #stamp{font-size:.85rem;color:#aaa;margin-bottom:10px}
 button{border:1px solid var(--orange);background:none;color:var(--orange);padding:6px 18px;cursor:pointer}
 main{padding:0 10px 40px}


### PR DESCRIPTION
## Summary
- show current BTC price in index page
- style price text
- fetch price from CoinGecko via proxies
- document the price feature

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_685ef9347b54833389c8105d723da4a4