### PR TITLE
Add TradingView chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BTC-Treasury-Tickers
 
 This project hosts a tiny web page that displays the current Bitcoin price.
-The price is fetched from CoinGecko via open CORS proxies and updates automatically every minute.
-Open `docs/index.html` in a browser to see the live value.
+The numeric value still comes from CoinGecko, but a TradingView chart is embedded so you can follow the live price action.
+Open `docs/index.html` in a browser to see the chart and price updates every minute.

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,21 @@
     <button id="reload">↻ refresh</button>
   </header>
 
+  <div id="chart" class="tradingview-widget-container"></div>
+
+  <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js" async>
+  {
+    "symbol": "BITSTAMP:BTCUSD",
+    "width": "100%",
+    "height": "300",
+    "locale": "en",
+    "dateRange": "12M",
+    "colorTheme": "dark",
+    "isTransparent": true,
+    "autosize": true
+  }
+  </script>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,7 +5,8 @@ nav{display:flex;gap:18px;padding:12px 24px;background:#1a1a1a}
 nav a{color:var(--fg);text-decoration:none}
 nav a.logo{font-weight:700;color:var(--orange)}
 #root,body,html{height:100%}
-header{display:flex;flex-direction:column;justify-content:center;align-items:center;height:100%}
+header{display:flex;flex-direction:column;justify-content:center;align-items:center;padding:40px 0}
+#chart{max-width:960px;margin:0 auto 40px}
 h1{color:var(--orange);font-size:2rem;margin-bottom:6px}
 #price{font-size:6rem;margin:20px 0;font-weight:700}
 #stamp{font-size:.85rem;color:#aaa;margin-bottom:10px}


### PR DESCRIPTION
## Summary
- embed a TradingView chart on the main page
- adjust layout styling to fit the chart
- mention the chart in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685efd2a89448333bdc156cd815a8b4a