### PR TITLE
Fix chart scaling on mobile

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,2 +1,2 @@
 html,body{height:100%;margin:0;padding:0;background:#121212}
-#tv-chart{height:100vh;width:100vw}
+#tv-chart{height:100vh;height:100dvh;width:100%;}


### PR DESCRIPTION
## Summary
- ensure the TradingView chart uses dynamic viewport height
- remove use of `vw` width to avoid horizontal overflow on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f002466008333a44f527589886a45