### PR TITLE
Convert site into personal portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# BTC-Treasury-Tickers
+# Sam Carter Portfolio
 
-This project now hosts a single web page that displays a full TradingView chart
-for Bitcoin. Open `docs/index.html` in any browser to access the interactive
-chart.
+This repository contains a simple static portfolio website for **Sam Carter**.
+Open `docs/index.html` in your browser to view the site.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,28 +3,36 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Bitcoin Chart</title>
+  <title>Sam Carter • Portfolio</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="icon" type="image/png" href="https://bitcoin.org/img/icons/opengraph.png">
 </head>
 <body>
-  <div id="tv-chart"></div>
+  <nav>
+    <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="projects.html">Projects</a>
+  </nav>
 
-  <script type="text/javascript" src="https://s3.tradingview.com/tv.js"></script>
-  <script>
-    new TradingView.widget({
-      autosize: true,
-      symbol: "BITSTAMP:BTCUSD",
-      interval: "30",
-      timezone: "Etc/UTC",
-      theme: "dark",
-      style: "1",
-      locale: "en",
-      toolbar_bg: "#1a1a1a",
-      enable_publishing: false,
-      allow_symbol_change: true,
-      container_id: "tv-chart"
-    });
-  </script>
+  <header>
+    <h1>Welcome</h1>
+    <p>I'm Sam Carter, a full‑stack developer passionate about building clean and efficient web applications.</p>
+  </header>
+
+  <main>
+    <section>
+      <h2>Featured Project</h2>
+      <p>Take a look at my latest work, <a href="https://github.com/samuelpcarter/BTC-Treasury-Tickers" target="_blank">BTC Treasury Tickers</a>, an experiment in scraping public Bitcoin holdings.</p>
+    </section>
+
+    <section>
+      <h2>Contact</h2>
+      <p>Feel free to reach out at <a href="mailto:samcart37@gmail.com">samcart37@gmail.com</a>.</p>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 Sam Carter
+  </footer>
 </body>
 </html>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>About • Sam Carter</title>
+  <title>Projects • Sam Carter</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -15,12 +15,18 @@
   </nav>
 
   <header>
-    <h1>About Me</h1>
+    <h1>Projects</h1>
   </header>
 
   <main>
-    <p>Hi, I'm Sam Carter, a software developer focused on building web applications that are simple, fast and accessible.</p>
-    <p>When I'm not coding, I enjoy contributing to open source projects and exploring new technologies.</p>
+    <section>
+      <h2>BTC Treasury Tickers</h2>
+      <p>A static website that surfaces public companies reporting Bitcoin holdings.</p>
+    </section>
+    <section>
+      <h2>Portfolio Website</h2>
+      <p>This simple portfolio highlights my experience and recent work.</p>
+    </section>
   </main>
 
   <footer>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,2 +1,1 @@
-html,body{height:100%;margin:0;padding:0;background:#121212}
-#tv-chart{height:100vh;height:100dvh;width:100%;}
+*{box-sizing:border-box}body{margin:0;font-family:Arial,sans-serif;line-height:1.6;background:#fdfdfd;color:#333}nav{background:#2c3e50;color:#fff;padding:1rem;display:flex;gap:1rem}nav a{color:#fff;text-decoration:none}nav a.logo{font-weight:bold;margin-right:auto}header{text-align:center;padding:3rem 1rem}main{max-width:800px;margin:auto;padding:1rem}section{margin-bottom:2rem}footer{text-align:center;padding:1rem;background:#2c3e50;color:#fff}


### PR DESCRIPTION
## Summary
- replace Bitcoin chart page with a personal portfolio
- add about and projects pages
- update styling for a clean layout
- update README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685f1d3703f883338518f63ccde40fa3