### PR TITLE
Add mouse-controlled cube rotation

### DIFF
--- a/docs/cube.css
+++ b/docs/cube.css
@@ -3,6 +3,7 @@
   width: 240px;
   height: 240px;
   margin: 2rem auto;
+  user-select: none;
 }
 
 #cube {
@@ -12,6 +13,8 @@
   margin: auto;
   transform-style: preserve-3d;
   transform: rotateX(-30deg) rotateY(45deg);
+  transition: transform 0.2s ease;
+  cursor: grab;
 }
 
 .face {
@@ -39,3 +42,7 @@
 #R { transform: rotateY(90deg) translateZ(60px); }
 
 .controls { text-align: center; margin-bottom: 1rem; }
+
+#cube.dragging {
+  cursor: grabbing;
+}

--- a/docs/cube.js
+++ b/docs/cube.js
@@ -134,6 +134,67 @@ const faceTransforms = {
 
 const faceAxis = { U: 'Y', D: 'Y', F: 'Z', B: 'Z', L: 'X', R: 'X' };
 
+let rotX = -30;
+let rotY = 45;
+let dragging = false;
+let startX, startY;
+
+function updateCubeRotation() {
+  const cubeEl = document.getElementById('cube');
+  cubeEl.style.transform = `rotateX(${rotX}deg) rotateY(${rotY}deg)`;
+}
+
+function initMouseControls() {
+  const scene = document.getElementById('scene');
+  const cubeEl = document.getElementById('cube');
+
+  scene.addEventListener('mousedown', e => {
+    dragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+    cubeEl.classList.add('dragging');
+  });
+
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    rotY += dx * 0.4;
+    rotX -= dy * 0.4;
+    updateCubeRotation();
+    startX = e.clientX;
+    startY = e.clientY;
+  });
+
+  document.addEventListener('mouseup', () => {
+    dragging = false;
+    cubeEl.classList.remove('dragging');
+  });
+
+  scene.addEventListener('touchstart', e => {
+    dragging = true;
+    startX = e.touches[0].clientX;
+    startY = e.touches[0].clientY;
+  });
+
+  scene.addEventListener('touchmove', e => {
+    if (!dragging) return;
+    const dx = e.touches[0].clientX - startX;
+    const dy = e.touches[0].clientY - startY;
+    rotY += dx * 0.4;
+    rotX -= dy * 0.4;
+    updateCubeRotation();
+    startX = e.touches[0].clientX;
+    startY = e.touches[0].clientY;
+  });
+
+  document.addEventListener('touchend', () => {
+    dragging = false;
+  });
+
+  updateCubeRotation();
+}
+
 function animateAndRotate(face, fn) {
   const el = document.getElementById(face);
   const axis = faceAxis[face];
@@ -147,7 +208,10 @@ function animateAndRotate(face, fn) {
   }, 300);
 }
 
-document.addEventListener('DOMContentLoaded', setup);
+document.addEventListener('DOMContentLoaded', () => {
+  setup();
+  initMouseControls();
+});
 document.addEventListener('keydown', e => {
   switch(e.key.toUpperCase()) {
     case 'U': return animateAndRotate('U', rotateU);

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
 <body>
   <header>
     <h1>Rubik's Cube Simulator</h1>
-    <p>Press U, D, F, B, L, R keys to rotate faces or use the buttons below.</p>
+    <p>Press U, D, F, B, L, R keys to rotate faces. Drag the cube to look around.</p>
   </header>
   <div class="controls">
     <button onclick="scramble()">Scramble</button>


### PR DESCRIPTION
## Summary
- allow drag rotation of the cube with smoother animation
- show grabbing cursor on drag
- hint about mouse controls in the instructions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686d50baeec88333acfaccd2a37c7691